### PR TITLE
Add workflow for npm publishing

### DIFF
--- a/.github/workflows/npm-publish.yml
+++ b/.github/workflows/npm-publish.yml
@@ -1,0 +1,49 @@
+name: Publish to npm
+on:
+  release:
+    types: [released]
+
+jobs:
+  publish:
+    runs-on: ubuntu-latest
+    steps:
+      - name: '[Prep 1] Checkout'
+        uses: actions/checkout@v2
+        with:
+          ref: ${{ github.event.release.tag_name }}
+      - name: '[Prep 2] Cache node modules'
+        uses: actions/cache@v2
+        with:
+          path: |
+            ~/.npm
+            ~/.nvm/.cache
+            ~/.nvm/versions
+          key: ${{ runner.os }}-build-cache-node-modules-${{ hashFiles('**/package-lock.json') }}
+          restore-keys: |
+            ${{ runner.os }}-build-cache-node-modules-
+      - name: '[Prep 3] Setup Node'
+        uses: actions/setup-node@v3
+        with:
+          node-version: 16
+      - name: '[Install] Install'
+        run: npm ci
+      - name: '[Build] all'
+        run: npm run build:all
+      - name: '[Version] set from tag name'
+        run: node -e "const fs=require('fs'); let file=JSON.parse(fs.readFileSync('package.json','utf8')); file.version='${{ github.event.release.tag_name }}'.substring(1); fs.writeFileSync('package.json',JSON.stringify(file,null,2));"
+      - name: '[Clean]'
+        run: npm run cleanforpublish
+      - name: '[Report] Show contents for publish'
+        run: ls -ltr && cat package.json
+      - name: '[Publish] npmjs.org'
+        run: npm publish
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_AUTH }}
+      - name: '[Setup] node registry'
+        uses: actions/setup-node@v3
+        with:
+          registry-url: 'https://npm.pkg.github.com'
+      - name: '[Publish] npm.pkg.github.com'
+        run: npm publish
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/npm-publish.yml
+++ b/.github/workflows/npm-publish.yml
@@ -39,11 +39,3 @@ jobs:
         run: npm publish
         env:
           NODE_AUTH_TOKEN: ${{ secrets.NPM_AUTH }}
-      - name: '[Setup] node registry'
-        uses: actions/setup-node@v3
-        with:
-          registry-url: 'https://npm.pkg.github.com'
-      - name: '[Publish] npm.pkg.github.com'
-        run: npm publish
-        env:
-          NODE_AUTH_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "TSTerm",
   "version": "1.0.1",
-  "description": "TSTerm is a software package that provides 3270 terminal functionality in a TypeScript implementation.   A brief explanation of the project can be found at:",
+  "description": "TSTerm is a software package that provides 3270 terminal functionality in a TypeScript implementation.",
   "main": "./lib/tsterm.min.js",
   "type": "module", 
   "types": "./lib/tsterm.d.ts",
@@ -12,15 +12,16 @@
     "build:dts": "dts-bundle-generator -o ./lib/tsterm.d.ts ./src/publicApi.ts",
     "build:dts:iife": "dts-bundle-generator -o ./lib/iife/tsterm.d.ts ./src/publicApi.ts",
     "test": "echo \"Error: no test specified\" && exit 0",
-    "build:all": "npm run build && npm run build:iife && npm run build:dts && npm run build:dts:iife"
+    "build:all": "npm run build && npm run build:iife && npm run build:dts && npm run build:dts:iife",
+    "cleanforpublish": "rm -rf src historical .git* *.js"
   },
   "repository": {
     "type": "git",
     "url": "git+https://github.com/TSTerminal/TSTerm.git"
   },
-  "keywords": [],
+  "keywords": ["tn3270","zos","terminal"],
   "author": "",
-  "license": "ISC",
+  "license": "EPL-2.0",
   "bugs": {
     "url": "https://github.com/TSTerminal/TSTerm/issues"
   },


### PR DESCRIPTION
This adds an action which publishes to both npmjs.com and github's own npm place, requiring that you have set up the token "NPM_AUTH" equal to a token created for an account on npmjs.com, and "GITHUB_TOKEN" for the same purpose on github (uses a "classic" github access token with publish:write authority)

This action triggers when a release is released. That is, not a pre-release, and not a draft.
When triggered, it checks out the source code associated with the tag, builds the code from the tag (to ensure the release is identical to the source) and sets the package.json version equal to the tag version. The sandbox removes source code and publishes the built code.
