### PR TITLE
Rename `fu` to `destructiveBackspace`

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,13 +1,13 @@
 {
   "name": "tstermz",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
-      "name": "TSTerm",
-      "version": "1.0.0",
-      "license": "ISC",
+      "name": "tstermz",
+      "version": "1.0.1",
+      "license": "EPL-2.0",
       "devDependencies": {
         "@rollup/plugin-typescript": "^8.3.0",
         "dts-bundle-generator": "^6.7.0",

--- a/src/Model3270.ts
+++ b/src/Model3270.ts
@@ -2067,7 +2067,7 @@ export class VirtualScreen3270 extends PagedVirtualScreen {   // minified as lc
     eu:any;
     su:any;
     ou:boolean;
-    cu:boolean;
+    moveToEditable: boolean; // Was cu
     destructiveBackspace: boolean; // Was fu
     parser:TN3270EParser|null;
     Cu:any;
@@ -2188,7 +2188,7 @@ export class VirtualScreen3270 extends PagedVirtualScreen {   // minified as lc
 	this.eu = { passwordPrompt: "password" };
 	this.su = { uu: !1, hu: !1, ru: !1, au: !1 };
 	this.ou = true;
-	this.cu = true;
+	this.moveToEditable = true;
 	this.destructiveBackspace = false;
 	// JOE adds these
 	this.parser = null;  // many instances of this.Du in code
@@ -4012,39 +4012,39 @@ export class VirtualScreen3270 extends PagedVirtualScreen {   // minified as lc
 	this.renderer && this.renderer.redrawTransientElements();
     }
     
-    Cr(){ // (lc.prototype.Cr = function () {
-	let element = this.screenElements[this.cursorPos];
-	const field = element && element.field;
-	if (field && field.fieldData.isEditable() && this.cursorPos >= field.start){
-	    this.doDelete(); // INTERIM .mr
-	}
+    deleteOnCursorPosition() { // (lc.prototype.Cr = function () {
+		let element = this.screenElements[this.cursorPos];
+		const field = element && element.field;
+		if (field && field.fieldData.isEditable() && this.cursorPos >= field.start){
+			this.doDelete(); // INTERIM .mr
+		}
     }
     
-    Nr(){ // lc.prototype.Nr = function () {
+    moveBackAndDelete() { // lc.prototype.Nr = function () {
 	// *UNKNOWN* - why does this not wrap?? 
-	if (0 != this.cursorPos){
-	    this.modifyCursorPos(-1);
-	}
-	if (this.destructiveBackspace) {
-	    this.Cr();
-	}
+		if (0 != this.cursorPos){
+			this.modifyCursorPos(-1);
+		}
+		if (this.destructiveBackspace) {
+			this.deleteOnCursorPosition();
+		}
     }
     
-    Pr(){ // lc.prototype.Pr = function () {
-	let element = this.screenElements[this.cursorPos];
-	const t = element && element.field;
-	if (!t || this.cursorPos <= t.start || !t.fieldData.isEditable()) {
-            let t = this.findMatchingEditableField(this.cursorPos, !0);
-            if (t) {
-		const element2 = this.screenElements[t];
-		const l = element2 && element2.field;
-		l && ((t += l.fieldData.length - 1), Utils.protocolLogger.debug("Got editable field at " + t), this.setCursorPos(t), this.destructiveBackspace && this.doDelete());
-            }
-	} else this.Nr();
+    moveToEditableField(){ // lc.prototype.Pr = function () {
+		let element = this.screenElements[this.cursorPos];
+		const t = element && element.field;
+		if (!t || this.cursorPos <= t.start || !t.fieldData.isEditable()) {
+			let t = this.findMatchingEditableField(this.cursorPos, !0);
+			if (t) {
+				const element2 = this.screenElements[t];
+				const l = element2 && element2.field;
+				l && ((t += l.fieldData.length - 1), Utils.protocolLogger.debug("Got editable field at " + t), this.setCursorPos(t), this.destructiveBackspace && this.doDelete());
+			}
+		} else this.moveBackAndDelete();
     }
 
-    handleBackspace(){// (lc.prototype.rr = function () {
-	this.cu ? this.Pr() : this.Nr();
+    handleBackspace() {// (lc.prototype.rr = function () {
+		this.moveToEditable ? this.moveToEditableField(): this.moveBackAndDelete();
     }
 
     handleHome(){//(lc.prototype.ar = function () {

--- a/src/Model3270.ts
+++ b/src/Model3270.ts
@@ -2068,7 +2068,7 @@ export class VirtualScreen3270 extends PagedVirtualScreen {   // minified as lc
     su:any;
     ou:boolean;
     cu:boolean;
-    fu:boolean;
+    destructiveBackspace: boolean; // Was fu
     parser:TN3270EParser|null;
     Cu:any;
     na:any; // something to do with keepAlive
@@ -2189,7 +2189,7 @@ export class VirtualScreen3270 extends PagedVirtualScreen {   // minified as lc
 	this.su = { uu: !1, hu: !1, ru: !1, au: !1 };
 	this.ou = true;
 	this.cu = true;
-	this.fu = false;
+	this.destructiveBackspace = false;
 	// JOE adds these
 	this.parser = null;  // many instances of this.Du in code
 	this.Cu = null;      // many instances in code values in (2,4,88, and null)
@@ -4025,7 +4025,7 @@ export class VirtualScreen3270 extends PagedVirtualScreen {   // minified as lc
 	if (0 != this.cursorPos){
 	    this.modifyCursorPos(-1);
 	}
-	if (this.fu){  // *UNKNOWN* what does this.fu control?
+	if (this.destructiveBackspace) {
 	    this.Cr();
 	}
     }
@@ -4038,7 +4038,7 @@ export class VirtualScreen3270 extends PagedVirtualScreen {   // minified as lc
             if (t) {
 		const element2 = this.screenElements[t];
 		const l = element2 && element2.field;
-		l && ((t += l.fieldData.length - 1), Utils.protocolLogger.debug("Got editable field at " + t), this.setCursorPos(t), this.fu && this.doDelete());
+		l && ((t += l.fieldData.length - 1), Utils.protocolLogger.debug("Got editable field at " + t), this.setCursorPos(t), this.destructiveBackspace && this.doDelete());
             }
 	} else this.Nr();
     }


### PR DESCRIPTION
There was a complain from customer, that the backspace key is not deleting the characters, but only moving cursor back (left). It seems to be a default behavior for other terminals too, but anyway, I did some testing and it seems the `fu` is a switch:

* `false` - old school backspace (moving cursor only) 
* `true` - destructive backspace (deleting characters)

No change to code logic, just renaming
* `fu` to `destructiveBackspace`. This can be used as user defined option in the future.
* `cu` to `moveToEditable`
* Couple functions with new names and indentation changes
